### PR TITLE
Bump GitHub Actions to Node 16, per deprecation warning

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,5 +22,5 @@ outputs:
     description: 'Any broken links that were found from performing the initial check'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/